### PR TITLE
Host specification through `HD_HOST` env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 .coverage
 .coverage.*
 /dist
+.venv/

--- a/hyperdiv/main.py
+++ b/hyperdiv/main.py
@@ -28,7 +28,7 @@ def is_port_open(port):
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.settimeout(0.1)
     try:
-        sock.connect(("localhost", port))
+        sock.connect((os.environ.get("HD_HOST", "localhost"), port))
     except (socket.timeout, ConnectionRefusedError):
         return False
     finally:
@@ -64,7 +64,7 @@ def wait_for_port(port):
 def open_browser(port):
     def run():
         wait_for_port(port)
-        webbrowser.open(f"http://localhost:{port}")
+        webbrowser.open(f"http://{os.environ.get('HD_HOST', 'localhost')}:{port}")
 
     thread = threading.Thread(target=run)
     thread.start()

--- a/hyperdiv/server.py
+++ b/hyperdiv/server.py
@@ -28,10 +28,10 @@ class Server:
         self.stopping = False
 
     def listen(self):
-        self.server.listen(self.port)
+        self.server.listen(self.port, address=os.environ.get("HD_HOST", "localhost"))
 
     def start(self):
-        print(f"Running at http://localhost:{self.port}", file=sys.stderr)
+        print(f"Running at http://{os.environ.get('HD_HOST', 'localhost')}:{self.port}", file=sys.stderr)
         print("Ctrl-C to exit", file=sys.stderr)
 
         signal.signal(signal.SIGINT, self.stop)

--- a/hyperdiv/tests/server_tests.py
+++ b/hyperdiv/tests/server_tests.py
@@ -46,10 +46,10 @@ class MockServer:
             os.environ["HD_DEBUG"] = self.prev_debug
 
     def open_websocket(self):
-        return websocket.create_connection(f"ws://localhost:{self.port}/ws")
+        return websocket.create_connection(f"ws://{os.environ.get('HD_HOST', 'localhost')}:{self.port}/ws")
 
     def request_path(self, path):
-        return requests.get(f"http://localhost:{self.port}{path}").text
+        return requests.get(f"http://{os.environ.get('HD_HOST', 'localhost')}:{self.port}{path}").text
 
 
 def checkbox_app():


### PR DESCRIPTION
In the context of running this from a docker container, it would be practical to be able to bind to address `0.0.0.0` - this change facilitates specifying a custom address through the `HD_HOST` env variable.

It might be useful to have something like an app config class, but I'm unsure what other configuration (besides port + address) are relevant atm. 