### PR TITLE
Markdown fixes

### DIFF
--- a/hyperdiv/components/markdown.py
+++ b/hyperdiv/components/markdown.py
@@ -17,13 +17,17 @@ def mistune_renderer():
         def block_code(self, code, info=None):
             if info:
                 try:
-                    lexer = get_lexer_by_name(info.strip(), stripall=True)
+                    lexer = get_lexer_by_name(info.strip())
                 except Exception:
                     lexer = TextLexer()
                 formatter = html.HtmlFormatter(cssclass="codehilite", wrapcode=True)
                 code = highlight(code, lexer, formatter)
                 return code
-            return "<pre><code>" + mistune.escape(code) + "</code></pre>"
+            return (
+                '<div class="codehilite"><pre><code>'
+                + mistune.escape(code)
+                + "</code></pre></div>"
+            )
 
     return mistune.create_markdown(
         renderer=HighlightRenderer(escape=False),

--- a/hyperdiv/components/markdown.py
+++ b/hyperdiv/components/markdown.py
@@ -15,19 +15,14 @@ from .common.text_utils import concat_text
 def mistune_renderer():
     class HighlightRenderer(mistune.HTMLRenderer):
         def block_code(self, code, info=None):
-            if info:
-                try:
-                    lexer = get_lexer_by_name(info.strip())
-                except Exception:
-                    lexer = TextLexer()
-                formatter = html.HtmlFormatter(cssclass="codehilite", wrapcode=True)
-                code = highlight(code, lexer, formatter)
-                return code
-            return (
-                '<div class="codehilite"><pre><code>'
-                + mistune.escape(code)
-                + "</code></pre></div>"
-            )
+            if not info:
+                info = "text"
+            try:
+                lexer = get_lexer_by_name(info.strip())
+            except Exception:
+                lexer = TextLexer()
+            formatter = html.HtmlFormatter(cssclass="codehilite", wrapcode=True)
+            return highlight(code, lexer, formatter)
 
     return mistune.create_markdown(
         renderer=HighlightRenderer(escape=False),


### PR DESCRIPTION
This PR addresses #17 and fixes inconsistent/buggy handling of code blocks that specify a language and code blocks that do not specify a language.