### PR TITLE
Custom equalities

### DIFF
--- a/hyperdiv/__init__.py
+++ b/hyperdiv/__init__.py
@@ -2,6 +2,7 @@ from .main import run
 from .debug import logger
 from .cache import cached
 from .index_page import index_page
+from .equalities import register_equality
 from .design_tokens import (
     Spacing,
     Shadow,

--- a/hyperdiv/equalities.py
+++ b/hyperdiv/equalities.py
@@ -1,0 +1,29 @@
+equalities = dict()
+
+
+def register_equality(typ, fn):
+    """
+    Hyperdiv determines if prop values changed by doing `bool(old_value
+    != new_value)`. Some types override `!= (`__ne__`) to return
+    non-bool-like values, causing `bool(old_value != new_value) to fail.
+
+    Using `register_equality`, you can define a custom equality
+    function. The equality function takes two values of a given type
+    and returns `True` if the values are equal and `False` otherwise.
+
+    For example, Hyperdiv automatically adds a custom equality
+    function for `pandas.DataFrame`, like this:
+
+    ```py-nodemo
+    hd.register_equality(pandas.DataFrame, lambda df1, df2: df1.equals(df2))
+    ```
+    """
+    equalities[typ] = fn
+
+
+try:
+    from pandas import DataFrame
+
+    register_equality(DataFrame, lambda df1, df2: df1.equals(df2))
+except Exception:
+    pass

--- a/hyperdiv/prop.py
+++ b/hyperdiv/prop.py
@@ -129,12 +129,6 @@ class StoredProp:
                 return True
             if type(old) in equalities:
                 return not equalities[type(old)](old, new)
-            else:
-                for typ in equalities.keys():
-                    if issubclass(type(old), typ):
-                        equals = equalities[typ]
-                        equalities[type(old)] = equals
-                        return not equals(old, new)
 
             raise ValueError(f"Comparison of values of type {type(old)} failed: {e}")
 

--- a/hyperdiv/tests/equalities_tests.py
+++ b/hyperdiv/tests/equalities_tests.py
@@ -1,0 +1,44 @@
+from ..test_utils import MockRunner
+from ..components.state import state
+from ..components.button import button
+
+
+def test_dataframe_assignments():
+    try:
+        from pandas import DataFrame
+    except Exception:
+        return
+
+    state_key = None
+    a_key = None
+    b_key = None
+
+    def my_app():
+        nonlocal state_key, a_key, b_key
+
+        df_state = state(df=None)
+        state_key = df_state._key
+
+        a_button = button("A")
+        a_key = a_button._key
+        if a_button.clicked:
+            df_state.df = DataFrame(dict(A=[1, 2], B=[3, 4]))
+
+        b_button = button("B")
+        b_key = b_button._key
+        if b_button.clicked:
+            df_state.df = DataFrame(dict(A=[3, 4], B=[5, 6]))
+
+    with MockRunner(my_app) as mr:
+        assert mr.get_state(state_key, "df") is None
+
+        mr.process_updates([(a_key, "clicked", True)])
+
+        df = mr.get_state(state_key, "df")
+        assert isinstance(df, DataFrame)
+        assert df.equals(DataFrame(dict(A=[1, 2], B=[3, 4])))
+
+        mr.process_updates([(b_key, "clicked", True)])
+        df = mr.get_state(state_key, "df")
+        assert isinstance(df, DataFrame)
+        assert df.equals(DataFrame(dict(A=[3, 4], B=[5, 6])))


### PR DESCRIPTION
This PR adds a way to plug in custom comparison functions for prop values. It automatically adds a comparison function for `pandas.DataFrame`. Addresses #18 