### PR TITLE
Chart-scale-tick-labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 .coverage.*
 /dist
 .venv/
+.vscode/

--- a/hyperdiv/components/charts/bar_chart.py
+++ b/hyperdiv/components/charts/bar_chart.py
@@ -9,6 +9,8 @@ def bar_chart(
     x_axis="linear",
     y_axis="linear",
     hide_legend=False,
+    show_x_tick_labels=True,
+    show_y_tick_labels=True,
     **kwargs,
 ):
     """
@@ -31,5 +33,7 @@ def bar_chart(
         x_axis=x_axis,
         y_axis=y_axis,
         hide_legend=hide_legend,
+        show_x_tick_labels=show_x_tick_labels,
+        show_y_tick_labels=show_y_tick_labels,
         **kwargs,
     )

--- a/hyperdiv/components/charts/bar_chart.py
+++ b/hyperdiv/components/charts/bar_chart.py
@@ -11,6 +11,8 @@ def bar_chart(
     hide_legend=False,
     show_x_tick_labels=True,
     show_y_tick_labels=True,
+    y_min=None,
+    y_max=None,
     **kwargs,
 ):
     """
@@ -35,5 +37,7 @@ def bar_chart(
         hide_legend=hide_legend,
         show_x_tick_labels=show_x_tick_labels,
         show_y_tick_labels=show_y_tick_labels,
+        y_min=y_min,
+        y_max=y_max,
         **kwargs,
     )

--- a/hyperdiv/components/charts/bubble_chart.py
+++ b/hyperdiv/components/charts/bubble_chart.py
@@ -9,6 +9,8 @@ def bubble_chart(
     x_axis="linear",
     y_axis="linear",
     hide_legend=False,
+    show_x_tick_labels=True,
+    show_y_tick_labels=True,
     **kwargs,
 ):
     """
@@ -61,5 +63,7 @@ def bubble_chart(
         x_axis=x_axis,
         y_axis=y_axis,
         hide_legend=hide_legend,
+        show_x_tick_labels=show_x_tick_labels,
+        show_y_tick_labels=show_y_tick_labels,
         **kwargs,
     )

--- a/hyperdiv/components/charts/bubble_chart.py
+++ b/hyperdiv/components/charts/bubble_chart.py
@@ -11,6 +11,8 @@ def bubble_chart(
     hide_legend=False,
     show_x_tick_labels=True,
     show_y_tick_labels=True,
+    y_min=None,
+    y_max=None,
     **kwargs,
 ):
     """
@@ -65,5 +67,7 @@ def bubble_chart(
         hide_legend=hide_legend,
         show_x_tick_labels=show_x_tick_labels,
         show_y_tick_labels=show_y_tick_labels,
+        y_min=y_min,
+        y_max=y_max,
         **kwargs,
     )

--- a/hyperdiv/components/charts/cartesian_chart.py
+++ b/hyperdiv/components/charts/cartesian_chart.py
@@ -19,6 +19,8 @@ def cartesian_chart(
     x_axis="linear",
     y_axis="linear",
     hide_legend=False,
+    hide_y_tick_labels=False,
+    hide_x_tick_labels=False,
     **kwargs,
 ):
     """
@@ -50,6 +52,8 @@ def cartesian_chart(
     * `hide_legend`: Hides the clickable legend at the top of the
       chart. This legend is rendered automatically when `labels` is
       specified, unless this parameter is set to `False`.
+    * `hide_x_tick_labels`: Hides the tick labels on the x-axis. Tick labels are shown by default.
+    * `hide_y_tick_labels`: As above, but for the y-axis.
     * `**kwargs`: Component style and slot props that are passed
       upward to @component(chart).
 
@@ -132,6 +136,19 @@ def cartesian_chart(
     hd.line_chart(
         ((now, 20), (now+(2 * day), 100), (now+(18 * day), 80)),
         x_axis="timeseries",
+    )
+    ```
+
+    ## Scale and Ticks
+    You can choose to hide the tick labels on the X and Y axes using the 
+    `hide_x_tick_labels` and `hide_y_tick_labels` parameters
+    respectively.
+
+    ```py
+    hd.line_chart(
+        (2, 4, 10),
+        hide_x_tick_labels=True,
+        hide_y_tick_labels=True
     )
     ```
 
@@ -348,6 +365,9 @@ def cartesian_chart(
 
     x_axis_config["grid"] = dict(color=grid_color)
     y_axis_config["grid"] = dict(color=grid_color)
+
+    x_axis_config["ticks"] = dict(display=not hide_x_tick_labels)
+    y_axis_config["ticks"] = dict(display=not hide_y_tick_labels)
 
     # Hide the legend if (a) there are no dataset labels specified, or
     # (b) `hide_legend` is True.

--- a/hyperdiv/components/charts/cartesian_chart.py
+++ b/hyperdiv/components/charts/cartesian_chart.py
@@ -19,8 +19,8 @@ def cartesian_chart(
     x_axis="linear",
     y_axis="linear",
     hide_legend=False,
-    hide_y_tick_labels=False,
-    hide_x_tick_labels=False,
+    show_x_tick_labels=True,
+    show_y_tick_labels=True,
     **kwargs,
 ):
     """
@@ -52,8 +52,8 @@ def cartesian_chart(
     * `hide_legend`: Hides the clickable legend at the top of the
       chart. This legend is rendered automatically when `labels` is
       specified, unless this parameter is set to `False`.
-    * `hide_x_tick_labels`: Hides the tick labels on the x-axis. Tick labels are shown by default.
-    * `hide_y_tick_labels`: As above, but for the y-axis.
+    * `show_x_tick_labels`: Hides the tick labels on the x-axis. Tick labels are shown by default.
+    * `show_y_tick_labels`: As above, but for the y-axis.
     * `**kwargs`: Component style and slot props that are passed
       upward to @component(chart).
 
@@ -140,17 +140,16 @@ def cartesian_chart(
     ```
 
     ## Scale and Ticks
-    You can choose to hide the tick labels on the X and Y axes using the 
-    `hide_x_tick_labels` and `hide_y_tick_labels` parameters
-    respectively.
+    You can choose to show or hide the tick labels on the x- and y-axis using the 
+    `show_x_tick_labels` and `show_y_tick_labels` parameters. Tick labels are shown by default.
 
     ```py
-    hd.line_chart(
+    hd.cartesian_chart("bar",
         (2, 4, 10),
-        hide_x_tick_labels=True,
-        hide_y_tick_labels=True
+        show_x_tick_labels=False,
+        show_y_tick_labels=False
     )
-    ```
+    ```    
 
     ## Mixed Datasets
 
@@ -366,8 +365,8 @@ def cartesian_chart(
     x_axis_config["grid"] = dict(color=grid_color)
     y_axis_config["grid"] = dict(color=grid_color)
 
-    x_axis_config["ticks"] = dict(display=not hide_x_tick_labels)
-    y_axis_config["ticks"] = dict(display=not hide_y_tick_labels)
+    x_axis_config["ticks"] = dict(display=show_x_tick_labels)
+    y_axis_config["ticks"] = dict(display=show_y_tick_labels)
 
     # Hide the legend if (a) there are no dataset labels specified, or
     # (b) `hide_legend` is True.

--- a/hyperdiv/components/charts/cartesian_chart.py
+++ b/hyperdiv/components/charts/cartesian_chart.py
@@ -21,6 +21,8 @@ def cartesian_chart(
     hide_legend=False,
     show_x_tick_labels=True,
     show_y_tick_labels=True,
+    y_min=None,
+    y_max=None,
     **kwargs,
 ):
     """
@@ -140,16 +142,28 @@ def cartesian_chart(
     ```
 
     ## Scale and Ticks
-    You can choose to show or hide the tick labels on the x- and y-axis using the 
-    `show_x_tick_labels` and `show_y_tick_labels` parameters. Tick labels are shown by default.
+    You can choose to show or hide the tick labels on the x- and
+    y-axis using the `show_x_tick_labels` and `show_y_tick_labels`
+    parameters. Tick labels are shown by default.
 
     ```py
-    hd.cartesian_chart("bar",
-        (2, 4, 10),
+    hd.bar_chart(
+        (2, 6, 10),
         show_x_tick_labels=False,
         show_y_tick_labels=False
     )
+    ```
+    You can control the y-axis scale using the `y_min` and `y_max`
+    parameters. These are overridden if the data exceeds the defined
+    scale.
+    ```py
+    hd.bar_chart(
+        (2, 6, 11), # 11 exceeds the max value
+        y_min=-10,
+        y_max=10
+    )
     ```    
+
 
     ## Mixed Datasets
 
@@ -367,6 +381,9 @@ def cartesian_chart(
 
     x_axis_config["ticks"] = dict(display=show_x_tick_labels)
     y_axis_config["ticks"] = dict(display=show_y_tick_labels)
+
+    y_axis_config["suggestedMin"] = y_min
+    y_axis_config["suggestedMax"] = y_max
 
     # Hide the legend if (a) there are no dataset labels specified, or
     # (b) `hide_legend` is True.

--- a/hyperdiv/components/charts/cartesian_chart.py
+++ b/hyperdiv/components/charts/cartesian_chart.py
@@ -56,6 +56,8 @@ def cartesian_chart(
       specified, unless this parameter is set to `False`.
     * `show_x_tick_labels`: Hides the tick labels on the x-axis. Tick labels are shown by default.
     * `show_y_tick_labels`: As above, but for the y-axis.
+    * `y_min`: The minimum value of the y-axis. This is overridden if a data value is less than this value.
+    * `y_max`: As above, but for the maximum value of the y-axis.
     * `**kwargs`: Component style and slot props that are passed
       upward to @component(chart).
 

--- a/hyperdiv/components/charts/line_chart.py
+++ b/hyperdiv/components/charts/line_chart.py
@@ -9,6 +9,8 @@ def line_chart(
     x_axis="linear",
     y_axis="linear",
     hide_legend=False,
+    show_x_tick_labels=True,
+    show_y_tick_labels=True,
     **kwargs,
 ):
     """
@@ -32,5 +34,7 @@ def line_chart(
         x_axis=x_axis,
         y_axis=y_axis,
         hide_legend=hide_legend,
+        show_x_tick_labels=show_x_tick_labels,
+        show_y_tick_labels=show_y_tick_labels,
         **kwargs,
     )

--- a/hyperdiv/components/charts/line_chart.py
+++ b/hyperdiv/components/charts/line_chart.py
@@ -11,6 +11,8 @@ def line_chart(
     hide_legend=False,
     show_x_tick_labels=True,
     show_y_tick_labels=True,
+    y_min=None,
+    y_max=None,
     **kwargs,
 ):
     """
@@ -36,5 +38,7 @@ def line_chart(
         hide_legend=hide_legend,
         show_x_tick_labels=show_x_tick_labels,
         show_y_tick_labels=show_y_tick_labels,
+        y_min=y_min,
+        y_max=y_max,
         **kwargs,
     )

--- a/hyperdiv/components/charts/polar_chart.py
+++ b/hyperdiv/components/charts/polar_chart.py
@@ -9,6 +9,7 @@ def polar_chart(
     colors=None,
     grid_color="neutral-100",
     hide_legend=False,
+    show_tick_labels=True,
     **kwargs,
 ):
     """
@@ -39,6 +40,16 @@ def polar_chart(
     )
     ```
 
+    You can show or hide the tick labels using the `show_tick_labels` parameter. They are shown by default.
+    ```py
+    hd.polar_chart(
+        (4, 6, 4, 8, 2),
+        colors=("red-200", "orange-200", "blue-100", "green-300", "yellow"),
+        labels=("Oats", "Milk", "Cheese", "Garlic", "Onions"),
+        show_tick_labels=False
+    )
+    ```
+
     """
     grid_color = Color.render(Color.parse(grid_color))
 
@@ -46,7 +57,7 @@ def polar_chart(
     config["options"]["scales"] = dict(
         r=dict(
             grid=dict(color=grid_color),
-            ticks=dict(showLabelBackdrop=False),
+            ticks=dict(showLabelBackdrop=False, display=show_tick_labels),
         ),
     )
 

--- a/hyperdiv/components/charts/polar_chart.py
+++ b/hyperdiv/components/charts/polar_chart.py
@@ -10,6 +10,8 @@ def polar_chart(
     grid_color="neutral-100",
     hide_legend=False,
     show_tick_labels=True,
+    r_min=None,
+    r_max=None,
     **kwargs,
 ):
     """
@@ -57,7 +59,12 @@ def polar_chart(
     config["options"]["scales"] = dict(
         r=dict(
             grid=dict(color=grid_color),
-            ticks=dict(showLabelBackdrop=False, display=show_tick_labels),
+            ticks=dict(
+                showLabelBackdrop=False, 
+                display=show_tick_labels,
+                suggestedMin=r_min,
+                suggestedMax=r_max,
+            ),
         ),
     )
 

--- a/hyperdiv/components/charts/polar_chart.py
+++ b/hyperdiv/components/charts/polar_chart.py
@@ -31,24 +31,28 @@ def polar_chart(
     ```
 
     The slice colors can be customized using the `colors` argument,
-    and the legend can be hidden:
+    and the legend and tick labels can be hidden.
 
     ```py
     hd.polar_chart(
         (4, 6, 4, 8, 2),
         colors=("red-200", "orange-200", "blue-100", "green-300", "yellow"),
         labels=("Oats", "Milk", "Cheese", "Garlic", "Onions"),
-        hide_legend=True
+        hide_legend=True,
+        show_tick_labels=False
     )
     ```
 
-    You can show or hide the tick labels using the `show_tick_labels` parameter. They are shown by default.
+    You can set the minimum and maximum values for the radar chart
+    using the `r_min` and `r_max` parameters. These are overridden if
+    the dataset values exceed the scale.
     ```py
     hd.polar_chart(
-        (4, 6, 4, 8, 2),
+        (4, 6, 4, 11, 2), # 11 exceeds the r_max
         colors=("red-200", "orange-200", "blue-100", "green-300", "yellow"),
         labels=("Oats", "Milk", "Cheese", "Garlic", "Onions"),
-        show_tick_labels=False
+        r_min=-10,
+        r_max=10
     )
     ```
 

--- a/hyperdiv/components/charts/polar_chart.py
+++ b/hyperdiv/components/charts/polar_chart.py
@@ -59,11 +59,11 @@ def polar_chart(
     config["options"]["scales"] = dict(
         r=dict(
             grid=dict(color=grid_color),
+            suggestedMin=r_min,
+            suggestedMax=r_max,
             ticks=dict(
                 showLabelBackdrop=False, 
                 display=show_tick_labels,
-                suggestedMin=r_min,
-                suggestedMax=r_max,
             ),
         ),
     )

--- a/hyperdiv/components/charts/radar_chart.py
+++ b/hyperdiv/components/charts/radar_chart.py
@@ -11,6 +11,8 @@ def radar_chart(
     grid_color="neutral-100",
     hide_legend=False,
     show_tick_labels=True,
+    r_min=None,
+    r_max=None,
     **kwargs,
 ):
     """A radar chart component.
@@ -103,7 +105,12 @@ def radar_chart(
                 scales=dict(
                     r=dict(
                         grid=dict(color=grid_color),
-                        ticks=dict(showLabelBackdrop=False, display=show_tick_labels),
+                        ticks=dict(
+                            showLabelBackdrop=False, 
+                            display=show_tick_labels,
+                            suggestedMin=r_min,
+                            suggestedMax=r_max,
+                        ),
                     ),
                 ),
             ),

--- a/hyperdiv/components/charts/radar_chart.py
+++ b/hyperdiv/components/charts/radar_chart.py
@@ -10,6 +10,7 @@ def radar_chart(
     colors=None,
     grid_color="neutral-100",
     hide_legend=False,
+    show_tick_labels=True,
     **kwargs,
 ):
     """A radar chart component.
@@ -50,6 +51,18 @@ def radar_chart(
         hide_legend=True,
     )
     ```
+    You can show or hide the tick labels using the `show_tick_labels` parameter. They are shown by default.
+    ```py
+    hd.radar_chart(
+        (1, 4, 2, 4),
+        (8, 6, 4, 8),
+        labels=("Jim", "Alice"),
+        colors=("fuchsia", "yellow"),
+        axis=("Commits", "PRs", "Issues", "Discussions"),
+        show_tick_labels=False
+    )
+    ```
+
 
     """
     if not datasets:
@@ -90,7 +103,7 @@ def radar_chart(
                 scales=dict(
                     r=dict(
                         grid=dict(color=grid_color),
-                        ticks=dict(showLabelBackdrop=False),
+                        ticks=dict(showLabelBackdrop=False, display=show_tick_labels),
                     ),
                 ),
             ),

--- a/hyperdiv/components/charts/radar_chart.py
+++ b/hyperdiv/components/charts/radar_chart.py
@@ -40,7 +40,7 @@ def radar_chart(
     ```
 
     `colors` can be a list of Hyperdiv colors, overriding the
-    automatically generated colors. And `hide_legend` can hide the
+    automatically generated colors, and `hide_legend` can hide the
     clickable dataset legend. You can show or hide the tick labels
     using the `show_tick_labels` parameter. They are shown by default.
 
@@ -57,10 +57,11 @@ def radar_chart(
     ```
 
     You can set the minimum and maximum values for the radar chart
-    using the `r_min` and `r_max` parameters.
+    using the `r_min` and `r_max` parameters. These are overridden if
+    the dataset values exceed the scale.
     ```py
     hd.radar_chart(
-        (1, 4, 2, 4),
+        (1, 4, 2, 11), # 11 exceeds the r_max
         axis=("Commits", "PRs", "Issues", "Discussions"),
         r_min=-10,
         r_max=10

--- a/hyperdiv/components/charts/radar_chart.py
+++ b/hyperdiv/components/charts/radar_chart.py
@@ -41,7 +41,8 @@ def radar_chart(
 
     `colors` can be a list of Hyperdiv colors, overriding the
     automatically generated colors. And `hide_legend` can hide the
-    clickable dataset legend.
+    clickable dataset legend. You can show or hide the tick labels
+    using the `show_tick_labels` parameter. They are shown by default.
 
     ```py
     hd.radar_chart(
@@ -51,17 +52,18 @@ def radar_chart(
         colors=("fuchsia", "yellow"),
         axis=("Commits", "PRs", "Issues", "Discussions"),
         hide_legend=True,
+        show_tick_labels=False
     )
     ```
-    You can show or hide the tick labels using the `show_tick_labels` parameter. They are shown by default.
+
+    You can set the minimum and maximum values for the radar chart
+    using the `r_min` and `r_max` parameters.
     ```py
     hd.radar_chart(
         (1, 4, 2, 4),
-        (8, 6, 4, 8),
-        labels=("Jim", "Alice"),
-        colors=("fuchsia", "yellow"),
         axis=("Commits", "PRs", "Issues", "Discussions"),
-        show_tick_labels=False
+        r_min=-10,
+        r_max=10
     )
     ```
 
@@ -105,11 +107,11 @@ def radar_chart(
                 scales=dict(
                     r=dict(
                         grid=dict(color=grid_color),
+                        suggestedMin=r_min,
+                        suggestedMax=r_max,
                         ticks=dict(
                             showLabelBackdrop=False, 
                             display=show_tick_labels,
-                            suggestedMin=r_min,
-                            suggestedMax=r_max,
                         ),
                     ),
                 ),

--- a/hyperdiv/components/charts/scatter_chart.py
+++ b/hyperdiv/components/charts/scatter_chart.py
@@ -11,6 +11,8 @@ def scatter_chart(
     hide_legend=False,
     show_x_tick_labels=True,
     show_y_tick_labels=True,
+    y_min=None,
+    y_max=None,
     **kwargs,
 ):
     """
@@ -35,5 +37,7 @@ def scatter_chart(
         hide_legend=hide_legend,
         show_x_tick_labels=show_x_tick_labels,
         show_y_tick_labels=show_y_tick_labels,
+        y_min=y_min,
+        y_max=y_max,
         **kwargs,
     )

--- a/hyperdiv/components/charts/scatter_chart.py
+++ b/hyperdiv/components/charts/scatter_chart.py
@@ -9,6 +9,8 @@ def scatter_chart(
     x_axis="linear",
     y_axis="linear",
     hide_legend=False,
+    show_x_tick_labels=True,
+    show_y_tick_labels=True,
     **kwargs,
 ):
     """
@@ -31,5 +33,7 @@ def scatter_chart(
         x_axis=x_axis,
         y_axis=y_axis,
         hide_legend=hide_legend,
+        show_x_tick_labels=show_x_tick_labels,
+        show_y_tick_labels=show_y_tick_labels,
         **kwargs,
     )

--- a/hyperdiv/components/charts/tests/chart_tests.py
+++ b/hyperdiv/components/charts/tests/chart_tests.py
@@ -151,12 +151,19 @@ def test_cartesian_chart():
             )
 
         # Hide x tick labels
-        c = cartesian_chart("bar", (1, 2, 3), show_x_tick_labels=False)
+        c = cartesian_chart(
+            "bar", 
+            (1, 2, 3), 
+            show_x_tick_labels=False,
+            show_y_tick_labels=False,
+        )
         assert c.config["options"]["scales"]["x"]["ticks"]["display"] is False
-
-        # Hide y tick labels 
-        c = cartesian_chart("bar", (1, 2, 3), show_y_tick_labels=False)
         assert c.config["options"]["scales"]["y"]["ticks"]["display"] is False
+
+        # Set y-axis scale
+        c = cartesian_chart("bar", (1, 2, 3), y_min=-10, y_max=10)
+        assert c.config["options"]["scales"]["y"]["suggestedMin"] == -10
+        assert c.config["options"]["scales"]["y"]["suggestedMax"] == 10
 
 
 @mock_frame
@@ -216,8 +223,10 @@ def test_polar_chart():
         # TODO
         polar_chart((1, 2, 3))
 
-        c = polar_chart((1, 2, 3), labels=("A", "B", "C"), show_tick_labels=False)
+        c = polar_chart((1, 2, 3), labels=("A", "B", "C"), show_tick_labels=False, r_min=-10, r_max=10)
         assert c.config["options"]["scales"]["r"]["ticks"]["display"] is False
+        assert c.config["options"]["scales"]["r"]["ticks"]["suggestedMin"] == -10
+        assert c.config["options"]["scales"]["r"]["ticks"]["suggestedMax"] == 10
 
 
 @mock_frame
@@ -230,8 +239,16 @@ def test_radar_chart():
         # TODO
         radar_chart((1, 2, 3), (2, 3, 4))
 
-        c = radar_chart((1, 2, 3), (2, 3, 4), (3, 4, 5), labels=("A", "B", "C"), show_tick_labels=False)
+        c = radar_chart(
+            (1, 2, 3), (2, 3, 4), (3, 4, 5), 
+            labels=("A", "B", "C"), 
+            show_tick_labels=False, 
+            r_min=-10, 
+            r_max=10
+        )
         assert c.config["options"]["scales"]["r"]["ticks"]["display"] is False
+        assert c.config["options"]["scales"]["r"]["ticks"]["suggestedMin"] == -10
+        assert c.config["options"]["scales"]["r"]["ticks"]["suggestedMax"] == 10
 
 def test_color_wraparound():
     gen = auto_color_generator()

--- a/hyperdiv/components/charts/tests/chart_tests.py
+++ b/hyperdiv/components/charts/tests/chart_tests.py
@@ -216,6 +216,9 @@ def test_polar_chart():
         # TODO
         polar_chart((1, 2, 3))
 
+        c = polar_chart((1, 2, 3), labels=("A", "B", "C"), show_tick_labels=False)
+        assert c.config["options"]["scales"]["r"]["ticks"]["display"] is False
+
 
 @mock_frame
 def test_radar_chart():
@@ -227,6 +230,8 @@ def test_radar_chart():
         # TODO
         radar_chart((1, 2, 3), (2, 3, 4))
 
+        c = radar_chart((1, 2, 3), (2, 3, 4), (3, 4, 5), labels=("A", "B", "C"), show_tick_labels=False)
+        assert c.config["options"]["scales"]["r"]["ticks"]["display"] is False
 
 def test_color_wraparound():
     gen = auto_color_generator()

--- a/hyperdiv/components/charts/tests/chart_tests.py
+++ b/hyperdiv/components/charts/tests/chart_tests.py
@@ -225,8 +225,8 @@ def test_polar_chart():
 
         c = polar_chart((1, 2, 3), labels=("A", "B", "C"), show_tick_labels=False, r_min=-10, r_max=10)
         assert c.config["options"]["scales"]["r"]["ticks"]["display"] is False
-        assert c.config["options"]["scales"]["r"]["ticks"]["suggestedMin"] == -10
-        assert c.config["options"]["scales"]["r"]["ticks"]["suggestedMax"] == 10
+        assert c.config["options"]["scales"]["r"]["suggestedMin"] == -10
+        assert c.config["options"]["scales"]["r"]["suggestedMax"] == 10
 
 
 @mock_frame
@@ -247,8 +247,8 @@ def test_radar_chart():
             r_max=10
         )
         assert c.config["options"]["scales"]["r"]["ticks"]["display"] is False
-        assert c.config["options"]["scales"]["r"]["ticks"]["suggestedMin"] == -10
-        assert c.config["options"]["scales"]["r"]["ticks"]["suggestedMax"] == 10
+        assert c.config["options"]["scales"]["r"]["suggestedMin"] == -10
+        assert c.config["options"]["scales"]["r"]["suggestedMax"] == 10
 
 def test_color_wraparound():
     gen = auto_color_generator()

--- a/hyperdiv/components/charts/tests/chart_tests.py
+++ b/hyperdiv/components/charts/tests/chart_tests.py
@@ -150,13 +150,13 @@ def test_cartesian_chart():
                 "bar", dict(label="A", data=(1, 2, 3)), dict(data=(4, 5, 6))
             )
 
-        # Hide y tick labels 
-        c = cartesian_chart("bar", (1, 2, 3), hide_y_tick_labels=True)
-        assert c.config["options"]["scales"]["y"]["ticks"]["display"] is False
-
         # Hide x tick labels
-        c = cartesian_chart("bar", (1, 2, 3), hide_x_tick_labels=True)
+        c = cartesian_chart("bar", (1, 2, 3), show_x_tick_labels=False)
         assert c.config["options"]["scales"]["x"]["ticks"]["display"] is False
+
+        # Hide y tick labels 
+        c = cartesian_chart("bar", (1, 2, 3), show_y_tick_labels=False)
+        assert c.config["options"]["scales"]["y"]["ticks"]["display"] is False
 
 
 @mock_frame

--- a/hyperdiv/components/charts/tests/chart_tests.py
+++ b/hyperdiv/components/charts/tests/chart_tests.py
@@ -150,6 +150,14 @@ def test_cartesian_chart():
                 "bar", dict(label="A", data=(1, 2, 3)), dict(data=(4, 5, 6))
             )
 
+        # Hide y tick labels 
+        c = cartesian_chart("bar", (1, 2, 3), hide_y_tick_labels=True)
+        assert c.config["options"]["scales"]["y"]["ticks"]["display"] is False
+
+        # Hide x tick labels
+        c = cartesian_chart("bar", (1, 2, 3), hide_x_tick_labels=True)
+        assert c.config["options"]["scales"]["x"]["ticks"]["display"] is False
+
 
 @mock_frame
 def test_cartesian_constructors():


### PR DESCRIPTION
resolves #34 

# Changes
- Adds `.vscode/` to `.gitignore` file
- Adds `show_x_tick_labels`, `show_y_tick_labels`, and `show_tick_labels` as appropriate to all charts.
- Adds `y_min` & `y_max` or `r_min` and `r_max` as appropriate to all charts.
- Tests added for this config
- Documentation updated to include the changes

# Design
Had two thoughts about design during this. In two minds about both, so open to making changes.
1. I made separate `y_min` and `y_max` params instead a single tuple of `y_scale`, as the latter might be a little less handy when you want to set only the min or max (though could set the non-set value to `None`).
2. Made the tick labels a `show...` instead of a `hide...` to avoid double negatives, although this contrasts with `hide_legend`.