### PR TITLE
Plugins

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -10,6 +10,7 @@ import { updateStyle, removeStyles, removeAllStyles } from "./css.js";
 import { singletons, getInitialUpdates } from "./singletons.js";
 import { applyPendingCallbacks } from "./next-update.js";
 import { executeCommands } from "./commands.js";
+import "./plugins.js";
 import { locationSingleton } from "./singletons/location-singleton.js";
 import {
   getScrollPositions,

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -10,7 +10,7 @@ import { updateStyle, removeStyles, removeAllStyles } from "./css.js";
 import { singletons, getInitialUpdates } from "./singletons.js";
 import { applyPendingCallbacks } from "./next-update.js";
 import { executeCommands } from "./commands.js";
-import "./plugins.js";
+import { clearPluginCache } from "./plugins.js";
 import { locationSingleton } from "./singletons/location-singleton.js";
 import {
   getScrollPositions,
@@ -115,6 +115,7 @@ const updateCaches = (cache, styleCache) => {
 const setRootDom = (dom) => {
   // First, clear the existing element cache, plugin cache, and style
   // cache.
+  clearPluginCache();
   elementCache = {};
   removeAllStyles();
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -10,7 +10,6 @@ import { updateStyle, removeStyles, removeAllStyles } from "./css.js";
 import { singletons, getInitialUpdates } from "./singletons.js";
 import { applyPendingCallbacks } from "./next-update.js";
 import { executeCommands } from "./commands.js";
-import { clearPluginCache } from "./plugins.js";
 import { locationSingleton } from "./singletons/location-singleton.js";
 import {
   getScrollPositions,
@@ -115,7 +114,6 @@ const updateCaches = (cache, styleCache) => {
 const setRootDom = (dom) => {
   // First, clear the existing element cache, plugin cache, and style
   // cache.
-  clearPluginCache();
   elementCache = {};
   removeAllStyles();
 

--- a/frontend/src/plugins.js
+++ b/frontend/src/plugins.js
@@ -10,9 +10,6 @@ window.hyperdiv = {
     }
     pluginRegistry[name] = callback;
   },
-  sendUpdate: (key, propName, propValue) => {
-    websocket.sendUpdate([key, propName, propValue]);
-  },
 };
 
 const loadScript = (scriptType, script) => {

--- a/frontend/src/plugins.js
+++ b/frontend/src/plugins.js
@@ -14,24 +14,27 @@ window.hyperdiv = {
 
 const loadScript = (scriptType, script) => {
   if (script in pluginScriptCache) {
-    return pluginScriptCache[script];
+    return pluginScriptCache[script].promise;
   }
-  const ret = new Promise((resolve) => {
-    const scriptTag = document.createElement("script");
+  const element = document.createElement("script");
+  const promise = new Promise((resolve) => {
     if (scriptType === "js-link") {
-      scriptTag.src = script;
-      scriptTag.onload = () => {
+      element.src = script;
+      element.onload = () => {
         resolve();
       };
     } else if (scriptType === "js") {
       const body = document.createTextNode(script);
-      scriptTag.appendChild(body);
+      element.appendChild(body);
       resolve();
     }
-    document.head.appendChild(scriptTag);
+    document.head.appendChild(element);
   });
-  pluginScriptCache[script] = ret;
-  return ret;
+  pluginScriptCache[script] = {
+    promise,
+    element,
+  };
+  return promise;
 };
 
 class PluginContext {
@@ -123,5 +126,8 @@ customElements.define("hyperdiv-plugin", Plugin);
 
 export const clearPluginCache = () => {
   pluginRegistry = {};
+  for (const script of Object.values(pluginScriptCache)) {
+    script.element.remove();
+  }
   pluginScriptCache = {};
 };

--- a/frontend/src/plugins.js
+++ b/frontend/src/plugins.js
@@ -61,11 +61,12 @@ class Plugin extends HTMLElement {
     await Promise.all(scriptPromises);
 
     this.connected = true;
-    this.updateFunction = pluginRegistry[pluginName](
-      this.getAttribute("id"),
-      this.shadowRoot,
-      this.initialProps
-    );
+    this.updateFunction = pluginRegistry[pluginName]({
+      key: this.getAttribute("id"),
+      domElement: this.shadowRoot,
+      initialProps: this.initialProps,
+      assetsRoot: this.component.assetsRoot,
+    });
     this.initialProps = {};
   }
 

--- a/hyperdiv/__init__.py
+++ b/hyperdiv/__init__.py
@@ -3,6 +3,7 @@ from .debug import logger
 from .cache import cached
 from .index_page import index_page
 from .equalities import register_equality
+from .component_mixins import Boxy, Styled, Interactive, Slottable, Togglable
 from .design_tokens import (
     Spacing,
     Shadow,

--- a/hyperdiv/component_base.py
+++ b/hyperdiv/component_base.py
@@ -144,16 +144,22 @@ class Component(Collector):
     @classmethod
     @cache
     def _get_static_props(cls):
-        props = dict()
+        unique_props = dict()
         for klass in reversed(cls.__mro__[:-1]):
-            props.update(
+            unique_props.update(
                 {
                     attr.name: attr
                     for attr in klass.__dict__.values()
                     if isinstance(attr, Prop)
                 }
             )
-        return props.values()
+
+        props = unique_props.values()
+        camlcase_props = getattr(cls, "_camlcase_props", True)
+        if not camlcase_props:
+            for prop in props:
+                prop.camlcase_ui_name = False
+        return props
 
     @classmethod
     @cache

--- a/hyperdiv/plugin.py
+++ b/hyperdiv/plugin.py
@@ -91,6 +91,7 @@ class PluginAssetsCollector(type):
 
 class Plugin(Component, Styled, metaclass=PluginAssetsCollector):
     _tag = "hyperdiv-plugin"
+    _camlcase_props = False
 
     @staticmethod
     def js(asset):

--- a/hyperdiv/plugin.py
+++ b/hyperdiv/plugin.py
@@ -103,26 +103,41 @@ class PluginAssetsCollector(type):
 
 
 class Plugin(Component, Styled, metaclass=PluginAssetsCollector):
+    """
+    This class can be subclassed to define custom Hyperdiv components,
+    with custom Javascript, CSS, and other assets, such as images.
+
+    See [here](/reference/plugins) for a detailed dive into how
+    plugins work.
+    """
+
     _tag = "hyperdiv-plugin"
     _camlcase_props = False
 
     @staticmethod
     def js(asset):
+        """Helper to define an inline Javascript asset."""
         return ("js", asset)
 
     @staticmethod
     def css(asset):
+        """Helper to define an inline CSS asset."""
         return ("css", asset)
 
     @staticmethod
     def js_link(asset):
+        """Helper to define a Javascript link asset."""
         return ("js-link", asset)
 
     @staticmethod
     def css_link(asset):
+        """Helper to define a CSS link asset."""
         return ("css-link", asset)
 
     def render(self):
+        """
+        The JSON-rendered form of the plugin that is sent to the browser.
+        """
         klass = type(self)
         plugin_name = getattr(klass, "_name", None) or klass.__name__
 

--- a/hyperdiv/plugin.py
+++ b/hyperdiv/plugin.py
@@ -107,7 +107,7 @@ class Plugin(Component, Styled, metaclass=PluginAssetsCollector):
     This class can be subclassed to define custom Hyperdiv components,
     with custom Javascript, CSS, and other assets, such as images.
 
-    See [here](/reference/plugins) for a detailed dive into how
+    See [here](/guide/plugins) for a detailed dive into how
     plugins work.
     """
 

--- a/hyperdiv/plugin.py
+++ b/hyperdiv/plugin.py
@@ -2,6 +2,8 @@ from urllib.parse import urlparse
 import os
 from .component_base import Component
 
+PLUGINS_PREFIX = "/hyperdiv-plugins"
+
 
 def is_url(s):
     try:
@@ -13,7 +15,7 @@ def is_url(s):
 
 
 class PluginAssetsCollector(type):
-    plugin_assets: dict[str, str] = dict()
+    plugin_assets: dict = dict()
 
     def __new__(cls, clsname, bases, attrs):
         klass = super().__new__(cls, clsname, bases, attrs)
@@ -21,18 +23,52 @@ class PluginAssetsCollector(type):
         if clsname != "Plugin":
             plugin_name = getattr(klass, "_name", None) or klass.__name__
 
-            for typ, asset in klass._assets:
+            assets_root = getattr(klass, "assets_root", None)
+            assets = getattr(klass, "assets", None)
+
+            if not assets:
+                raise Exception(f"Plugin {plugin_name} does not specify any `assets`.")
+
+            local_assets = []
+            for typ, asset in klass.assets:
                 if typ in ("css-link", "js-link"):
-                    if is_url(asset):
-                        continue
-                    if not os.path.exists(asset):
+                    if not is_url(asset):
+                        local_assets.append((typ, asset))
+
+            if not local_assets:
+                return
+
+            if not assets_root:
+                raise Exception(
+                    f"Plugin {plugin_name} does not specify an `assets_root`"
+                )
+
+            if not os.path.exists(assets_root):
+                raise Exception(
+                    f"Plugin {plugin_name} `assets_root` {assets_root} does not exist."
+                )
+
+            if not os.path.isabs(assets_root):
+                raise Exception(
+                    f"Plugin {plugin_name} `assets_root` {assets_root} is not an absolute path."
+                )
+
+            assets_config = dict(
+                assets_root=assets_root,
+                assets=[],
+            )
+
+            PluginAssetsCollector.plugin_assets[plugin_name] = assets_config
+
+            for typ, asset_path in local_assets:
+                if typ in ("css-link", "js-link"):
+                    path = os.path.join(assets_root, asset_path)
+                    if not os.path.exists(path):
                         raise Exception(
-                            f'Asset "{asset}" is neither a URL nor a local file.'
+                            f"Asset path {asset_path} specified by plugin {plugin_name} does not exist."
                         )
-                    file_name = os.path.split(asset)[1]
-                    PluginAssetsCollector.plugin_assets[
-                        f"{plugin_name}/{file_name}"
-                    ] = asset
+
+                    assets_config["assets"].append(asset_path)
 
         return klass
 
@@ -57,17 +93,22 @@ class Plugin(Component, metaclass=PluginAssetsCollector):
         return ("css-link", asset)
 
     def render(self):
-        reverse_map = {
-            value: key for key, value in PluginAssetsCollector.plugin_assets.items()
-        }
+        klass = type(self)
+        plugin_name = getattr(klass, "_name", None) or klass.__name__
+
+        asset_paths = PluginAssetsCollector.plugin_assets.get(plugin_name, {}).get(
+            "assets", []
+        )
 
         output = super().render()
-        assets = type(self)._assets
-        output["assets"] = [
-            (
-                asset_type,
-                f"/plugins/{reverse_map[asset]}" if asset in reverse_map else asset,
-            )
-            for (asset_type, asset) in assets
-        ]
+        output["assets"] = []
+
+        for asset_type, asset in type(self).assets:
+            if asset in asset_paths:
+                output["assets"].append(
+                    (asset_type, f"{PLUGINS_PREFIX}/{plugin_name}/{asset}")
+                )
+            else:
+                output["assets"].append((asset_type, asset))
+
         return output

--- a/hyperdiv/prop.py
+++ b/hyperdiv/prop.py
@@ -25,6 +25,7 @@ class Prop:
         default_value=None,
         name=None,
         ui_name=None,
+        camlcase_ui_name=True,
         backend_immutable=False,
         internal=False,
     ):
@@ -32,6 +33,7 @@ class Prop:
         self.default_value = default_value
         self.name = name
         self.ui_name = ui_name
+        self.camlcase_ui_name = camlcase_ui_name
         self.backend_immutable = backend_immutable
         self.internal = internal
 
@@ -70,6 +72,7 @@ class StoredProp:
 
         self.name = prop.name
         self.ui_name = prop.ui_name
+        self.camlcase_ui_name = prop.camlcase_ui_name
         self.prop_type = prop.prop_type
         self.default_value = prop.default_value
         self.backend_immutable = prop.backend_immutable
@@ -101,7 +104,12 @@ class StoredProp:
         # are named `type` and `open` which are Python
         # keywords/built-ins. In that case, they'll be named
         # `item_type`, `opened` etc. on the Python side.
-        self.ui_name = to_caml_case(prop.ui_name or prop.name)
+        if prop.ui_name:
+            self.ui_name = prop.ui_name
+        elif self.camlcase_ui_name:
+            self.ui_name = to_caml_case(prop.name)
+        else:
+            self.ui_name = prop.name
 
     def init(self, value):
         """Called on every frame."""

--- a/hyperdiv/tests/plugin_tests.py
+++ b/hyperdiv/tests/plugin_tests.py
@@ -1,0 +1,236 @@
+import pytest
+import tempfile
+import os
+from ..test_utils import mock_frame
+from ..plugin import Plugin, PluginAssetsCollector, PLUGINS_PREFIX
+
+
+def test_plugin_incomplete_spec():
+    # No assets specified
+    with pytest.raises(Exception):
+
+        class BadPlugin1(Plugin):
+            pass
+
+    # Specifying local assets with _asset_root
+    with pytest.raises(Exception):
+
+        class BadPlugin2(Plugin):
+            _assets = ["foo.js"]
+
+    # Nonexisting asset root
+    with pytest.raises(Exception):
+
+        class BadPlugin3(Plugin):
+            _assets_root = "foo"
+            _assets = ["foo.js"]
+
+    # Nonexisting asset root
+    with pytest.raises(Exception):
+
+        class BadPlugin4(Plugin):
+            _assets_root = "foo"
+            _assets = ["foo.js"]
+
+    # Unknown extension
+    with pytest.raises(Exception):
+
+        class BadPlugin5(Plugin):
+            _assets = ["https://foo.com/foo.bar"]
+
+    # Bad asset type
+    with pytest.raises(Exception):
+
+        class BadPlugin6(Plugin):
+            _assets = [("bad-type", "https://foo.com/foo.js")]
+
+    # Too many description components
+    with pytest.raises(Exception):
+
+        class BadPlugin7(Plugin):
+            _assets = [("js-link", "https://foo.com/foo.js", "bar")]
+
+
+@mock_frame
+def test_plugin_nonexisting_local_asset():
+    with tempfile.TemporaryDirectory() as plugin_dir:
+
+        with pytest.raises(Exception):
+
+            class BadPlugin8(Plugin):
+                _assets_root = plugin_dir
+                _assets = ["plugin.js"]
+
+        with pytest.raises(Exception):
+
+            class BadPlugin9(Plugin):
+                _assets_root = plugin_dir
+                _assets = [Plugin.js_link("plugin.js")]
+
+
+@mock_frame
+def test_plugin_remote_assets():
+    # Remote assets without _assert_root is OK
+    class Plugin3(Plugin):
+        _assets = ["https://foo.com/foo.js", "https://foo.com/foo.css"]
+
+    assert "Plugin3" in PluginAssetsCollector.plugin_assets
+    assert set(PluginAssetsCollector.plugin_assets["Plugin3"]["assets"]) == set(
+        [
+            Plugin.js_link("https://foo.com/foo.js"),
+            Plugin.css_link("https://foo.com/foo.css"),
+        ]
+    )
+
+    p = Plugin3()
+    rendered = p.render()
+    assert set(rendered["assets"]) == set(
+        [
+            Plugin.js_link("https://foo.com/foo.js"),
+            Plugin.css_link("https://foo.com/foo.css"),
+        ]
+    )
+
+
+@mock_frame
+def test_plugin_local_assets():
+    with tempfile.TemporaryDirectory() as plugin_dir:
+        with open(os.path.join(plugin_dir, "plugin.js"), "w") as f:
+            f.write('console.log("Hello");')
+        with open(os.path.join(plugin_dir, "plugin.css"), "w") as f:
+            f.write(".foo { margin: 0 }")
+
+        class Plugin4(Plugin):
+            _assets_root = plugin_dir
+            _assets = [Plugin.js_link("plugin.js"), Plugin.css_link("plugin.css")]
+
+        assert "Plugin4" in PluginAssetsCollector.plugin_assets
+        assert (
+            PluginAssetsCollector.plugin_assets["Plugin4"]["assets_root"] == plugin_dir
+        )
+        assert set(PluginAssetsCollector.plugin_assets["Plugin4"]["assets"]) == set(
+            [Plugin.js_link("plugin.js"), Plugin.css_link("plugin.css")]
+        )
+
+        p = Plugin4()
+        rendered = p.render()
+        assert set(rendered["assets"]) == set(
+            [
+                Plugin.js_link(f"{PLUGINS_PREFIX}/Plugin4/plugin.js"),
+                Plugin.css_link(f"{PLUGINS_PREFIX}/Plugin4/plugin.css"),
+            ]
+        )
+
+
+@mock_frame
+def test_plugin_assets_glob():
+    with tempfile.TemporaryDirectory() as plugin_dir:
+        os.makedirs(os.path.join(plugin_dir, "a", "b", "c"))
+        os.makedirs(os.path.join(plugin_dir, "x", "y"))
+
+        with open(os.path.join(plugin_dir, "a", "b", "c", "js1.js"), "w") as f:
+            f.write('console.log("Hello 1");')
+        with open(os.path.join(plugin_dir, "a", "b", "js2.js"), "w") as f:
+            f.write('console.log("Hello 2");')
+        with open(os.path.join(plugin_dir, "x", "y", "style.css"), "w") as f:
+            f.write(".foo { margin: 0 }")
+
+        class Plugin4(Plugin):
+            _assets_root = plugin_dir
+            _assets = ["**/*.js", "**/*.css"]
+
+        assert "Plugin4" in PluginAssetsCollector.plugin_assets
+        assert (
+            PluginAssetsCollector.plugin_assets["Plugin4"]["assets_root"] == plugin_dir
+        )
+        assert set(PluginAssetsCollector.plugin_assets["Plugin4"]["assets"]) == set(
+            [
+                Plugin.js_link("a/b/c/js1.js"),
+                Plugin.js_link("a/b/js2.js"),
+                Plugin.css_link("x/y/style.css"),
+            ]
+        )
+
+        p = Plugin4()
+        rendered = p.render()
+
+        assert set(rendered["assets"]) == set(
+            [
+                Plugin.js_link(f"{PLUGINS_PREFIX}/Plugin4/a/b/c/js1.js"),
+                Plugin.js_link(f"{PLUGINS_PREFIX}/Plugin4/a/b/js2.js"),
+                Plugin.css_link(f"{PLUGINS_PREFIX}/Plugin4/x/y/style.css"),
+            ]
+        )
+
+
+@mock_frame
+def test_plugin_inline_assets():
+    inline_js = "console.log('Hello World');"
+    inline_css = ".foo { margin: 0}"
+
+    class Plugin5(Plugin):
+        _assets = [Plugin.js(inline_js), Plugin.css(inline_css)]
+
+    assert "Plugin5" in PluginAssetsCollector.plugin_assets
+    assert set(PluginAssetsCollector.plugin_assets["Plugin5"]["assets"]) == set(
+        [Plugin.js(inline_js), Plugin.css(inline_css)]
+    )
+
+    p = Plugin5()
+    rendered = p.render()
+    assert set(rendered["assets"]) == set(
+        [Plugin.js(inline_js), Plugin.css(inline_css)]
+    )
+
+
+@mock_frame
+def test_mixed_assets():
+    inline_js = "console.log('Hello World');"
+    inline_css = ".foo { margin: 0}"
+
+    with tempfile.TemporaryDirectory() as plugin_dir:
+        os.makedirs(os.path.join(plugin_dir, "a", "b", "c"))
+
+        with open(os.path.join(plugin_dir, "a", "b", "c", "plugin.js"), "w") as f:
+            f.write("console.log('Hello World');")
+        with open(os.path.join(plugin_dir, "style.css"), "w") as f:
+            f.write(".foo { margin: 0 }")
+
+        class Plugin6(Plugin):
+            _assets_root = plugin_dir
+            _assets = [
+                "**/*.js",
+                "style.css",
+                Plugin.js(inline_js),
+                Plugin.css(inline_css),
+                "https://foo.com/script.js",
+                "https://foo.com/style.css",
+            ]
+
+        assert "Plugin6" in PluginAssetsCollector.plugin_assets
+        assert (
+            PluginAssetsCollector.plugin_assets["Plugin6"]["assets_root"] == plugin_dir
+        )
+        assert set(PluginAssetsCollector.plugin_assets["Plugin6"]["assets"]) == set(
+            [
+                Plugin.js(inline_js),
+                Plugin.css(inline_css),
+                Plugin.js_link("a/b/c/plugin.js"),
+                Plugin.css_link("style.css"),
+                Plugin.js_link("https://foo.com/script.js"),
+                Plugin.css_link("https://foo.com/style.css"),
+            ]
+        )
+
+        p = Plugin6()
+        rendered = p.render()
+        assert set(rendered["assets"]) == set(
+            [
+                Plugin.js(inline_js),
+                Plugin.css(inline_css),
+                Plugin.js_link(f"{PLUGINS_PREFIX}/Plugin6/a/b/c/plugin.js"),
+                Plugin.css_link(f"{PLUGINS_PREFIX}/Plugin6/style.css"),
+                Plugin.js_link("https://foo.com/script.js"),
+                Plugin.css_link("https://foo.com/style.css"),
+            ]
+        )

--- a/hyperdiv/tests/plugin_tests.py
+++ b/hyperdiv/tests/plugin_tests.py
@@ -234,3 +234,31 @@ def test_mixed_assets():
                 Plugin.css_link("https://foo.com/style.css"),
             ]
         )
+
+
+@mock_frame
+def test_assets_root():
+    with tempfile.TemporaryDirectory() as plugin_dir:
+
+        class Plugin7(Plugin):
+            _assets_root = plugin_dir
+            _assets = ["https://foo.com/foo.js"]
+
+        assert (
+            PluginAssetsCollector.plugin_assets["Plugin7"]["assets_root"] == plugin_dir
+        )
+
+        p = Plugin7()
+        rendered = p.render()
+
+        assert rendered["assetsRoot"] == f"{PLUGINS_PREFIX}/Plugin7"
+
+    class Plugin8(Plugin):
+        _assets = ["https://foo.com/foo.js"]
+
+    assert PluginAssetsCollector.plugin_assets["Plugin8"]["assets_root"] is None
+
+    p = Plugin8()
+    rendered = p.render()
+
+    assert "assetsRoot" not in rendered


### PR DESCRIPTION
Concurrent docs PR: https://github.com/hyperdiv/hyperdiv-docs/pull/8

This PR adds functionality to extend Hyperdiv with custom components, with custom Javascript and CSS assets, as well as other assets, like images, text files, etc.

A Plugin interface already existed in Hyperdiv but it was previously undocumented and unsupported. This PR breaks code that used that previous plugin interface.

## Overview

From a programmer's perspective, a plugin works identically to a Hyperdiv built-in component. It can define props, it can be instantiated multiple times in the same app, and each instance will have independent prop state. Props can be read and mutated just like Hyperdiv props.

A plugin's front-end implementation is wrapped din a [Web Component](https://developer.mozilla.org/en-US/docs/Web/API/Web_components). The plugin's frontend is rendered inside the wrapper Web Component's shadow root. Hyperdiv manages the wrapper component and provides its shadow root to the plugin. The plugin can then render its contents inside the shadow root.

Being a Web Component, the plugin's CSS assets will be naturally isolated inside the Web Component, and not interfere with other CSS in the app. However, the plugin's Javascript assets are not isolated. They are inserted in the global `<head>` tag of the application. As such, plugin Javascript should take precautions to not pollute the global scope or interfere with other code/data in the global scope.

## Defining a Plugin

A plugin is defined by subclassing `hd.Plugin`. A plugin can provide local and remote assets. If a plugin provides local assets, it must set the `_assets_root` class variable, which is an absolute path to a directory that contains the plugin's assets. Then, the plugin defines its local assets using the `_assets` class variable, which is a list of paths *relative to* the `_assets_root`. The plugin interface will automatically detect JS and CSS assets based on the file extension -- `.js` and `.css` -- and load them appropriately. If assets have exotic file extensions, wrappers `hd.Plugin.css_link` and `hd.Plugin.js_link` force Hyperdiv to assume an asset is a CSS asset or a JS asset, respectively.

In addition to assets, plugins can then define Hyperdiv props that work identically to Hyperdiv built-in component props.

## Registering a Plugin

One of the assets has to be a piece of Javascript that registers the plugin with the Hyperdiv frontend. On registration, Hyperdiv provides the plugin's frontend with an object that contains the wrapper Web Component's shadow root, the plugin's initial props (the props with which the plugin is instantiated in Python), and methods to (a) send a prop update to Python when that prop is updated in the browser and (b) handle incoming prop updates from Python. This way, the plugin's frontend is in charge of keeping its props in sync with Python.

## Example

An example counter plugin:

```py
import os
import hyperdiv as hd

class my_counter(hd.Plugin):
    _assets_root = os.path.join(os.path.dirname(__file__), "assets")
    _assets = ["counter.js", "counter.css"]

    count = hd.Prop(hd.Int, 0)
```

The plugin organization on disk:

```
counter_plugin/
    __init__.py
    my_counter.py # The Python code above
    assets/
        counter.js
        counter.css
```

The contents of `counter.js`:

```js
window.hyperdiv.registerPlugin("counter", (ctx) => {
  let count = 0;
  const button = document.createElement("button");
  button.innerText = "Increment";
  const countDiv = document.createElement("div");

  const updateCount = (newCount) => {
    count = newCount;
    countDiv.innerText = count;
  };

  // On click, increment the count and send the updated
  // prop value to Python:
  button.addEventListener("click", () => {
    updateCount(count + 1);
    ctx.updateProp("count", count);
  });

  // Handle incoming prop updates from Python. We ignore
  // `propName` because there is only one prop, "count".
  ctx.onPropUpdate((propName, propValue) => {
    updateCount(propValue);
  });

  // Add the dom elements to the shadow root.
  ctx.domElement.appendChild(button);
  ctx.domElement.appendChild(countDiv);

  // Initialize the plugin with the initial count.
  updateCount(ctx.initialProps.count);
});
```

## Differences from previously undocumented `hd.Plugin`

* For local assets, `_assets` are now relative paths, relative to `_assets_root`.
* No need to specify `('css-link', 'foo.js')`. If assets have extension `.js` or `.css`, you now refer to asset paths with plain `'foo.js'` and `'foo.css'`. If assets have nonstandard extensions, you can use or the helpers `hd.Plugin.css_link(...)` and `hd.Plugin.js_link(...)`.
* On the frontend, `hyperdiv.sendUpdate` has been removed, and the registration callback receives an object. The object provides methods `updateProp(propName, propValue)` (replacing `hyperdiv.sendUpdate`) and `onPropUpdate(callback)` (replacing the need to return an update callback). The object also provides attributes `initialProps`, `domElement`, and `assetsRoot`.
* On the frontend, incoming props are no longer caml-cased. Props names are now identical to the prop names as defined by Python.
* The plugin can load additional assets from the provided `assetsRoot`. It could load images, for example.

cc @tkriplean @johnny-smitherson 